### PR TITLE
Upgrade for Python >= 3.6, drop support for older versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.7
   - 3.6
   - 3.7
   - 3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ python:
   - 3.7
   - 3.8
 before_script:
-  - pip install filesystem_tree pyflakes pytest>=2.4 .
-script: ./runtests.sh
+  - pip install tox-travis
+script: tox
 notifications:
   email: false
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
 python:
   - 2.7
-  - 3.4
-  - 3.5
+  - 3.6
+  - 3.7
+  - 3.8
 before_script:
   - pip install filesystem_tree pyflakes pytest>=2.4 .
 script: ./runtests.sh

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,4 +1,4 @@
 #!/bin/sh -eu
-python state_chain.py  # doctests
+python -m doctest state_chain.py
 py.test -v tests.py
 pyflakes state_chain.py tests.py

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,4 +1,0 @@
-#!/bin/sh -eu
-python -m doctest state_chain.py
-py.test -v tests.py
-pyflakes state_chain.py tests.py

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from setuptools import setup
 
 
@@ -15,12 +13,7 @@ setup( name='state_chain'
                    , 'Intended Audience :: Developers'
                    , 'License :: OSI Approved :: MIT License'
                    , 'Operating System :: OS Independent'
-                   , 'Programming Language :: Python :: 2'
-                   , 'Programming Language :: Python :: 2.6'
-                   , 'Programming Language :: Python :: 2.7'
                    , 'Programming Language :: Python :: 3'
-                   , 'Programming Language :: Python :: 3.2'
-                   , 'Programming Language :: Python :: 3.3'
                    , 'Topic :: Software Development :: Libraries :: Python Modules'
                     ]
       )

--- a/state_chain.py
+++ b/state_chain.py
@@ -209,9 +209,6 @@ class StateChain(object):
 
     """
 
-    functions = None        #: A list of functions comprising the algorithm.
-    default_raise_immediately = False
-
     START = -1
     END = -2
 

--- a/state_chain.py
+++ b/state_chain.py
@@ -154,7 +154,6 @@ API Reference
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import collections
 import opcode
 import sys
 import types
@@ -220,7 +219,7 @@ class StateChain(object):
     def __init__(self, *functions, **kw):
         self.default_raise_immediately = kw.pop('raise_immediately', False)
         if functions:
-            if not isinstance(functions[0], collections.Callable):
+            if not callable(functions[0]):
                 raise TypeError("Not a function: {0}".format(repr(functions[0])))
         self.functions = list(functions)
         self._signatures = {}

--- a/state_chain.py
+++ b/state_chain.py
@@ -359,7 +359,7 @@ class StateChain(object):
         >>> algo['bar']
         Traceback (most recent call last):
           ...
-        FunctionNotFound: The function 'bar' isn't in this state chain.
+        state_chain.FunctionNotFound: The function 'bar' isn't in this state chain.
 
         """
         func = None

--- a/state_chain.py
+++ b/state_chain.py
@@ -9,7 +9,7 @@ Installation
     $ pip install state_chain
 
 The version of :py:mod:`state_chain` documented here has been `tested`_ against
-Python 2.7, 3.4, and 3.5 on Ubuntu.
+Python 2.7, 3.6, 3.7 and 3.8 on Ubuntu.
 
 :py:mod:`state_chain` is MIT-licensed.
 

--- a/state_chain.py
+++ b/state_chain.py
@@ -811,9 +811,3 @@ def debug(function):
                                       )
 
     return new_function
-
-
-if __name__ == '__main__':
-    import doctest
-    import sys
-    sys.exit(min(doctest.testmod()[0], 1))

--- a/state_chain.py
+++ b/state_chain.py
@@ -218,9 +218,9 @@ class StateChain(object):
 
     def __init__(self, *functions, **kw):
         self.default_raise_immediately = kw.pop('raise_immediately', False)
-        if functions:
-            if not callable(functions[0]):
-                raise TypeError("Not a function: {0}".format(repr(functions[0])))
+        for f in functions:
+            if not callable(f):
+                raise TypeError("Not a function: {0}".format(repr(f)))
         self.functions = list(functions)
         self._signatures = {}
         self.debug = _DebugMethod(self)

--- a/state_chain.py
+++ b/state_chain.py
@@ -215,7 +215,6 @@ class StateChain(object):
     START = -1
     END = -2
 
-
     def __init__(self, *functions, **kw):
         self.default_raise_immediately = kw.pop('raise_immediately', False)
         for f in functions:
@@ -349,7 +348,6 @@ class StateChain(object):
 
         return state
 
-
     def __getitem__(self, name):
         """Return the function in the :py:attr:`functions` list named ``name``, or raise
         :py:exc:`FunctionNotFound`.
@@ -373,12 +371,10 @@ class StateChain(object):
             raise FunctionNotFound(name)
         return func
 
-
     def get_names(self):
         """Returns a list of the names of the functions in the :py:attr:`functions` list.
         """
         return [f.__name__ for f in self.functions]
-
 
     def insert_before(self, name, *newfuncs):
         """Insert ``newfuncs`` in the :py:attr:`functions` list before the function named
@@ -413,7 +409,6 @@ class StateChain(object):
             i = self.functions.index(self[name])
         self.functions[i:i] = newfuncs
 
-
     def insert_after(self, name, *newfuncs):
         """Insert ``newfuncs`` in the :py:attr:`functions` list after the function named
         ``name``, or raise :py:exc:`FunctionNotFound`.
@@ -446,7 +441,6 @@ class StateChain(object):
             i = self.functions.index(self[name]) + 1
         self.functions[i:i] = newfuncs
 
-
     def remove(self, *names):
         """Remove the functions named ``name`` from the :py:attr:`functions` list, or raise
         :py:exc:`FunctionNotFound`.
@@ -454,7 +448,6 @@ class StateChain(object):
         for name in names:
             func = self[name]
             self.functions.remove(func)
-
 
     @classmethod
     def from_dotted_name(cls, dotted_name, **kw):
@@ -499,7 +492,6 @@ class StateChain(object):
         module = cls._load_module_from_dotted_name(dotted_name)
         functions = cls._load_functions_from_module(module)
         return cls(*functions, **kw)
-
 
     def debug(self, function):
         """Given a function, return a copy of the function with a breakpoint
@@ -587,7 +579,6 @@ class StateChain(object):
         """
         raise NotImplementedError  # Should be overriden by _DebugMethod in constructor.
 
-
     # Helpers for loading from a file.
     # ================================
 
@@ -599,7 +590,6 @@ class StateChain(object):
         for name in dotted_name.split('.'):
             module = getattr(module, name)
         return module
-
 
     @staticmethod
     def _load_functions_from_module(module):

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import sys
 
 import traceback

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35
+envlist = py27,py36,py37,py38
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37,py38
+envlist = py36,py37,py38
 
 [testenv]
 deps =
@@ -9,5 +9,5 @@ deps =
 commands =
     python -m pytest -v tests.py {posargs}
     pyflakes state_chain.py tests.py
-    !py27: python -m doctest state_chain.py
+    python -m doctest state_chain.py
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,8 @@ deps =
     filesystem_tree
     pyflakes
     pytest>=2.4
-commands = {posargs:./runtests.sh}
+commands =
+    python -m pytest -v tests.py {posargs}
+    pyflakes state_chain.py tests.py
+    !py27: python -m doctest state_chain.py
 usedevelop = True


### PR DESCRIPTION
This branch adds support for Python 3.6, 3.7 and 3.8, and removes support for 2.7, 3.4 and 3.5.

CPython 3.6 changed the bytecode structure, from a variable number of bytes per instruction to exactly 2 bytes per instruction. (A new `EXTENDED_ARG` instruction is used when instruction arguments don't fit in a single byte.)

Python 3.8 added support for positional-only arguments, through a new `co_posonlyargcount` attribute on code objects.